### PR TITLE
Add description for IO errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -61,7 +61,7 @@ impl error::Error for Error {
 
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Error {
-        Error { kind: ErrorKind::Io(err), description: "".to_owned() }
+        Error { description: format!("IO error: {}", err.to_string()), kind: ErrorKind::Io(err) }
     }
 }
 


### PR DESCRIPTION
Noticed that when I ran `write_to_path` with a non-existing path, there was no error message. With this PR, the error message would be `IO Error: No such file or directory (os error 2)`.