### PR TITLE
Fix track number parsing bug with Apple Music

### DIFF
--- a/src/tag/tuple.rs
+++ b/src/tag/tuple.rs
@@ -204,14 +204,24 @@ fn total(vec: &[u8]) -> Option<u16> {
 
 fn set_number(vec: &mut Vec<u8>, number: u16) {
     set_be_int!(vec, 2, number, u16);
+    check_correct_size(vec);
 }
 
 fn set_total(vec: &mut Vec<u8>, total: u16) {
     set_be_int!(vec, 4, total, u16);
+    check_correct_size(vec);
+}
+
+// NOTE: iTunes/Apple Music requires the atom size to be 8 bytes for correct parsing.
+//       Smaller sizes 6 bytes for example will cause parsing issues.
+fn check_correct_size(vec: &mut Vec<u8>) {
+    if vec.len() < 8 {
+        vec.resize(8, 0);
+    }
 }
 
 fn new(number: u16, total: u16) -> Vec<u8> {
     let [n0, n1] = number.to_be_bytes();
     let [t0, t1] = total.to_be_bytes();
-    vec![0, 0, n0, n1, t0, t1]
+    vec![0, 0, n0, n1, t0, t1, 0, 0]
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use mp4ameta::ident::TRACK_NUMBER;
 use mp4ameta::{
     AdvisoryRating, ChannelConfig, Data, Fourcc, Img, MediaType, SampleRate, Tag, STANDARD_GENRES,
 };
@@ -530,6 +531,15 @@ fn track_disc_handling() {
     assert_eq!(tag.disc(), (None, None));
     assert_eq!(tag.disc_number(), None);
     assert_eq!(tag.total_discs(), None);
+
+    // Test if track number atom is corrected to the right size when edited.
+    tag.set_data(TRACK_NUMBER, Data::Reserved(vec![0, 0, 0, 1]));
+    tag.set_total_tracks(2);
+    assert_eq!(tag.track(), (Some(1), Some(2)));
+    assert_eq!(
+        tag.data_of(&TRACK_NUMBER).next(),
+        Some(&Data::Reserved(vec![0, 0, 0, 1, 0, 2, 0, 0]))
+    );
 }
 
 #[test]


### PR DESCRIPTION
Hey @saecki great crate you have build! I encountered some weird behavior with track numbers (`trkn` atoms) that where not correctly parsed by the latest Apple Music / iTunes on my Mac. Diffing the atom trees with `atomicparsley` I saw that there was a size difference:

## What this crate produces
```
Atom trkn @ 24924 of size: 30, ends @ 24954
    Atom data @ 24932 of size: 22, ends @ 24954
```

## What Apple Music produces
```
Atom trkn @ 24924 of size: 32, ends @ 24956
    Atom data @ 24932 of size: 24, ends @ 24956
```

Adding two extra zero bytes fixes the issue for me, now the track numbers are correctly parsed. Weirdly the disk number was already correctly parsed. I think on Apple side there are some bugs with parsing the atoms correctly because all the other tools parsed the correct track number atom correctly :|