### PR TITLE
feat: add publisher (©pub)

### DIFF
--- a/src/atom/ident.rs
+++ b/src/atom/ident.rs
@@ -107,6 +107,8 @@ pub const CUSTOM_GENRE: Fourcc = Fourcc(*b"\xa9gen");
 pub const DISC_NUMBER: Fourcc = Fourcc(*b"disk");
 /// (`©too`)
 pub const ENCODER: Fourcc = Fourcc(*b"\xa9too");
+/// (`©pub`)
+pub const PUBLISHER: Fourcc = Fourcc(*b"\xa9pub");
 /// (`gnre`)
 pub const STANDARD_GENRE: Fourcc = Fourcc(*b"gnre");
 /// (`©nam`)

--- a/src/tag/mod.rs
+++ b/src/tag/mod.rs
@@ -61,6 +61,7 @@ impl fmt::Display for Tag {
         self.format_keywords(f)?;
         self.format_copyright(f)?;
         self.format_encoder(f)?;
+        self.format_publisher(f)?;
         self.format_tv_show_name(f)?;
         self.format_tv_show_name_sort_order(f)?;
         self.format_tv_network_name(f)?;

--- a/src/tag/userdata/generate.toml
+++ b/src/tag/userdata/generate.toml
@@ -6,6 +6,7 @@
 "encoder"                 = "©too"
 "lyrics"                  = "©lyr"
 "movement"                = "©mvn"
+"publisher"               = "©pub"
 "title"                   = "©nam"
 "tv_episode_name"         = "tven"
 "tv_network_name"         = "tvnn"

--- a/src/tag/userdata/generated.rs
+++ b/src/tag/userdata/generated.rs
@@ -164,6 +164,38 @@ impl Userdata {
     }
 }
 
+/// ### Publisher
+impl Userdata {
+    /// Returns the publisher (`©pub`).
+    pub fn publisher(&self) -> Option<&str> {
+        self.strings_of(&ident::PUBLISHER).next()
+    }
+
+    /// Removes and returns the publisher (`©pub`).
+    pub fn take_publisher(&mut self) -> Option<String> {
+        self.take_strings_of(&ident::PUBLISHER).next()
+    }
+
+    /// Sets the publisher (`©pub`).
+    pub fn set_publisher(&mut self, publisher: impl Into<String>) {
+        self.set_data(ident::PUBLISHER, Data::Utf8(publisher.into()));
+    }
+
+    /// Removes the publisher (`©pub`).
+    pub fn remove_publisher(&mut self) {
+        self.remove_data_of(&ident::PUBLISHER);
+    }
+
+    /// Returns the publisher formatted in an easily readable way.
+    #[allow(unused)]
+    pub(crate) fn format_publisher(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.publisher() {
+            Some(s) => writeln!(f, "publisher: {}", s),
+            None => Ok(()),
+        }
+    }
+}
+
 /// ### Title
 impl Userdata {
     /// Returns the title (`©nam`).


### PR DESCRIPTION
Found myself using the publisher tag and discovered it was a 'simple tag' that existed in the standards for quite some time.

Looking at your recent "feat: add ..." commit, I tried to create the same for publisher and used the cargo run to generate the updated generated.rs which added publisher.

Hopefully this is to your liking and can be merged :)

Thanks for creating this library, it really helps me with audiobook tagging automation.